### PR TITLE
[CHORE] add pagerduty alerting on job failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,28 @@ jobs:
       - name: Run script
         working-directory: .github/scripts/ci_checks
         run: uv run main.py
+
+  alert-on-failure:
+    name: Create PagerDuty incident on failure
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs:
+      - ci-checks
+    steps:
+      - uses: Entle/action-pagerduty-alert@1.0.5
+        with:
+          pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+          pagerduty-dedup-key: ci-checks-failed
+
+  resolve-alert-on-success: 
+    name: Resolve PagerDuty incident on success
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ always() && !contains(needs.*.result, 'failure') }}
+    needs:
+      - ci-checks
+    steps:
+      - uses: Entle/action-pagerduty-alert@1.0.5
+        with:
+          pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+          pagerduty-dedup-key: ci-checks-failed
+          resolve: true

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -129,3 +129,30 @@ jobs:
           EOF
           )"
           git push origin staging
+
+  alert-on-failure:
+    name: Create PagerDuty incident on failure
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    needs:
+      - sync-production
+      - sync-staging
+    steps:
+      - uses: Entle/action-pagerduty-alert@1.0.5
+        with:
+          pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+          pagerduty-dedup-key: sync-failed
+
+  resolve-alert-on-success: 
+    name: Resolve PagerDuty incident on success
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ always() && !contains(needs.*.result, 'failure') }}
+    needs:
+      - sync-production
+      - sync-staging
+    steps:
+      - uses: Entle/action-pagerduty-alert@1.0.5
+        with:
+          pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+          pagerduty-dedup-key: sync-failed
+          resolve: true


### PR DESCRIPTION
We want to alert when the Sync and CI Checks workflows fail.