### PR TITLE
[CHORE] (prd) temporarily disable sync workflow

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -2,7 +2,7 @@ name: Sync Indexed Collections
 run-name: Sync Indexed Collections (${{ github.event_name == 'schedule' && 'production, staging' || github.event.inputs.environment }})
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Temporarily increase the frequency of the sync workflow to allow a utility script to run.