### PR TITLE
[CHORE] fix bundler gem tag format

### DIFF
--- a/ruby_gems/bundler/config.json
+++ b/ruby_gems/bundler/config.json
@@ -129,7 +129,7 @@
   "repo": "rubygems/rubygems",
   "sentinel_timestamp": "2020-01-01T00:00:00Z",
   "tag_formats": [
-    "v{major}.{minor}.{patch}"
+    "bundler-v{major}.{minor}.{patch}"
   ],
   "version_sample_max_size": 5,
   "version_sample_relative_size": 0.5


### PR DESCRIPTION
https://github.com/rubygems/rubygems uses `bundler-v{major}.{minor}.{patch}` for bundler releases