### PR TITLE
[BUG] run sync every 2 hours to prevent race condition with previous job

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -2,7 +2,7 @@ name: Sync Indexed Collections
 run-name: Sync Indexed Collections (${{ github.event_name == 'schedule' && 'production, staging' || github.event.inputs.environment }})
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */2 * * *'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Job was running every 1 hour

Job duration began to exceed 60 minutes

So, a race condition emerged causing jobs to fail.

